### PR TITLE
Swift version 5 update plus a new concurrency protocol for Core Data unchecked Sendable

### DIFF
--- a/CombineURLServices/CombineURLServices.xcodeproj/project.pbxproj
+++ b/CombineURLServices/CombineURLServices.xcodeproj/project.pbxproj
@@ -799,6 +799,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -854,6 +855,7 @@
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_VERSION = 5.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/CombineURLServices/DataFlowFunnelPersistance/DebugOperations/FetchAndDescribeDataOperation.swift
+++ b/CombineURLServices/DataFlowFunnelPersistance/DebugOperations/FetchAndDescribeDataOperation.swift
@@ -8,7 +8,7 @@ import Foundation
 import CoreData
 import DataFlowFunnelCD
 
-final class FetchAndDescribeDataOperation: Operation {
+final class FetchAndDescribeDataOperation: Operation, @unchecked Sendable {
     
     override init() {
         super.init()

--- a/CombineURLServices/IPGeoLocationModule/IPGeoLocationOperation/CreateIpGeoLocationOperation.swift
+++ b/CombineURLServices/IPGeoLocationModule/IPGeoLocationOperation/CreateIpGeoLocationOperation.swift
@@ -9,7 +9,7 @@ import Foundation
 import CoreData
 import DataFlowFunnelCD
 
-final class CreateIpGeoLocationOperation: Operation {
+final class CreateIpGeoLocationOperation: Operation, @unchecked Sendable {
     
     private var newIpLocation: IPLocation = IPLocation()
     private var requestID: UUID = UUID()

--- a/CombineURLServices/IPGeoLocationModule/IPGeoLocationOperation/CreateNetworkRequestGeoSearchViewOperation.swift
+++ b/CombineURLServices/IPGeoLocationModule/IPGeoLocationOperation/CreateNetworkRequestGeoSearchViewOperation.swift
@@ -14,7 +14,7 @@ import Foundation
 import CoreData
 import DataFlowFunnelCD
 
-final class CreateNetworkRequestGeoSearchViewOperation: Operation {
+final class CreateNetworkRequestGeoSearchViewOperation: Operation, @unchecked Sendable {
     
     var newIPText:String = String() // ip text injection
     var setTypeOfRequest:Int64 = NetworkRequestType.geosearch.rawValue

--- a/CombineURLServices/IPGeoLocationModule/IPGeoLocationOperation/DeleteIpGeoLocationRequestOperation.swift
+++ b/CombineURLServices/IPGeoLocationModule/IPGeoLocationOperation/DeleteIpGeoLocationRequestOperation.swift
@@ -9,7 +9,7 @@ import Foundation
 import CoreData
 import DataFlowFunnelCD
 
-final class DeleteIpGeoLocationNetworkRequestOperation: Operation {
+final class DeleteIpGeoLocationNetworkRequestOperation: Operation, @unchecked Sendable {
     
     var id: UUID = UUID()
     

--- a/CombineURLServices/IPGeoLocationModule/IPGeoLocationOperation/DeleteOlderIpGeoLocationEntriesOperation.swift
+++ b/CombineURLServices/IPGeoLocationModule/IPGeoLocationOperation/DeleteOlderIpGeoLocationEntriesOperation.swift
@@ -9,7 +9,7 @@ import Foundation
 import CoreData
 import DataFlowFunnelCD
 
-final class DeleteOlderIpGeoLocationEntriesOperation: Operation {
+final class DeleteOlderIpGeoLocationEntriesOperation: Operation, @unchecked Sendable {
     
     override init() {
         super.init()

--- a/CombineURLServices/IPGeoLocationModule/IPGeoLocationOperation/UpdateIpGeoLocationNetworkRequestOperation.swift
+++ b/CombineURLServices/IPGeoLocationModule/IPGeoLocationOperation/UpdateIpGeoLocationNetworkRequestOperation.swift
@@ -9,7 +9,7 @@ import Foundation
 import CoreData
 import DataFlowFunnelCD
 
-final class UpdateIpGeoLocationNetworkRequestOperation: Operation {
+final class UpdateIpGeoLocationNetworkRequestOperation: Operation, @unchecked Sendable {
     
     private var idToUpdate: UUID  = UUID()
     private var stateToUpdate: Int64 = 0

--- a/CombineURLServices/IPGeoLocationModule/IPGeoLocationOperation/UpdateIpGeoLocationOperation.swift
+++ b/CombineURLServices/IPGeoLocationModule/IPGeoLocationOperation/UpdateIpGeoLocationOperation.swift
@@ -21,7 +21,7 @@ import DataFlowFunnelCD
  a refreshed data set for that IP address.
  */
 
-final class UpdateIpGeoLocationOperation: Operation {
+final class UpdateIpGeoLocationOperation: Operation, @unchecked Sendable {
     
     private var localWithMessage: String  = String()
     private var localWithIpGeoLocation: IpGeoLocation = IpGeoLocation()

--- a/CombineURLServices/IPGeoLocationModule/View/GeoSearchView.swift
+++ b/CombineURLServices/IPGeoLocationModule/View/GeoSearchView.swift
@@ -10,6 +10,7 @@ import CoreData
 import Foundation
 
 struct GeoSearchView: View {
+    
     @StateObject private var viewModel = GeoSearchViewModel()
     var body: some View {
         VStack {

--- a/CombineURLServices/NetworkReachabilityModule/NetworkReachabilityOperations/UpdateReachabilityStatusOperation.swift
+++ b/CombineURLServices/NetworkReachabilityModule/NetworkReachabilityOperations/UpdateReachabilityStatusOperation.swift
@@ -8,7 +8,7 @@ import Foundation
 import CoreData
 import DataFlowFunnelCD
 
-final class UpdateReachabilityStatusOperation: Operation {
+final class UpdateReachabilityStatusOperation: Operation, @unchecked Sendable {
     
     var newCurrentStatus: String = String()
     


### PR DESCRIPTION
Swift version 5 update plus a new concurrency protocol for Core Data Operations has unchecked Sendable Operations has come up as a warning unchecked Sendable